### PR TITLE
Add a list-styli command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,12 @@ This is an inherent limitation of relocatable GSettings. To add this type of err
 currently implemented.
 
 ### No serial number detection
+
 `gsetwacom` cannot detect a stylus serial number, external tools need to be used to
-find the serial number of a stylus.
+find the serial number of a stylus. The `gsetwacom list-styli` tool currently uses
+the gnome-control-center (GNOME Settings) cache file for styli - this only works
+where GNOME Settings has "seen" the stylus before by bringing it into proximity
+above the GNOME Settings window.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,15 @@ For details on any command see `gsetwacom --help` or `gsetwacom <command> --help
 Examples for tablet configuration:
 ```
 $ gsetwacom list-devices
-- "HUION Huion Tablet_H641P Pen" (256C:0066)
-- "Wacom Intuos Pro M Pen" (056A:0357)
-- "Wacom Intuos Pro M Pad" (056A:0357)
-- "Wacom Intuos Pro M Finger" (056A:0357)
+devices:
+- name: "HUION Huion Tablet_H641P Pen"
+  usbid: "256C:0066"
+- name: "Wacom Intuos Pro M Pen"
+  usbid: "056A:0357"
+- name: "Wacom Intuos Pro M Pad"
+  usbid: "056A:0357"
+- name: "Wacom Intuos Pro M Finger"
+  usbid: "056A:0357"
 
 $ gsetwacom tablet "056A:0357" show
 area=[0.0, 0.0, 0.0, 0.0]

--- a/src/gsetwacom/__init__.py
+++ b/src/gsetwacom/__init__.py
@@ -48,6 +48,8 @@ def list_devices():
     """
     import pyudev
 
+    have_devices = False
+
     context = pyudev.Context()
     for device in filter(
         lambda d: Path(d.sys_path).name.startswith("event"),
@@ -62,8 +64,16 @@ def list_devices():
         if name is None:
             name = next(device.ancestors).get("NAME")
 
+        if not have_devices:
+            click.echo("devices:")
+            have_devices = True
+
         # udev NAME is already in quotes
-        click.echo(f"- {name} ({vid:04X}:{pid:04X})")
+        click.echo(f"- name: {name}")
+        click.echo(f'  usbid: "{vid:04X}:{pid:04X}"')
+
+    if not have_devices:
+        click.secho("No devices found")
 
 
 @gsetwacom.group()

--- a/src/gsetwacom/__init__.py
+++ b/src/gsetwacom/__init__.py
@@ -76,6 +76,31 @@ def list_devices():
         click.secho("No devices found")
 
 
+@gsetwacom.command()
+def list_styli():
+    """
+    List the styli previously seen on this system.
+
+    Only styli with unique serial numbers are listed.
+
+    This currently uses the gnome-control-center cache file, a device may not
+    be available until it has been brought into proximity above the
+    control center.
+    """
+    from configparser import ConfigParser
+
+    xdg = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    config = ConfigParser()
+    config.read(xdg / "gnome-control-center" / "wacom" / "tools")
+    if not config.sections():
+        click.secho("No styli found")
+        return
+
+    click.echo("styli:")
+    for section in config.sections():
+        click.echo(f" - serial number: {section}")
+
+
 @gsetwacom.group()
 @click.argument("device", type=str)
 @click.pass_context


### PR DESCRIPTION
gsettings doesn't have a relation between the tablets and the styli so there's no way to query the config for styli (short of digging around in dconf for which we don't have python bindings).

Luckily gnome-control-center keeps a cache file that we can peek at, so let's use that. Will work until the format of that changes, but that should be unlikely enough.