### PR TITLE
Check schema keys before accessing them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ line-length = 120
 ignore = [
   "FBT001",  # FBT001 Boolean-typed positional argument in function definition
   "S320",    # S320 Using `lxml` to parse untrusted data is known to be vulnerable to XML attacks
+  "S101",    # S101 Use of `assert` detectd
 ]
 
 [tool.hatch.version]

--- a/src/gsetwacom/__init__.py
+++ b/src/gsetwacom/__init__.py
@@ -26,7 +26,7 @@ logger.setLevel(logging.ERROR)
 @dataclass
 class Settings:
     path: str
-    settings: Gio.Settings | None
+    settings: Gio.Settings
 
 
 @click.group()


### PR DESCRIPTION
This fixes the current issues with `stylus ... show` when running on GNOME 46 or earlier. The newly supported keys (#12 and #9) don't exist yet, causing a crash.