### PR TITLE
Allow a tablet name of `first` to resolve to the first tablet

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ $ gsetwacom tablet "056A:0357" set-ring-action --direction=cw --mode=2 keybindin
 
 $ gsetwacom tablet "056A:0357" map-to-monitor --connector DP-1
 ```
+
+A special device name of `first` may be used instead of the vid/pid and will resolve
+to the vid/pid of the first tablet listed by `gsetwacom list-tablets`.
+
+```
+$ gsetwacom tablet "first" show
+```
+Note that unlike the vid/pid configuration, the special value `first` requires
+that the tablet is plugged in. This special value is for debugging only and should not
+be used in scripts.
+
 And for stylus configuration:
 ```
 settings:

--- a/src/gsetwacom/__init__.py
+++ b/src/gsetwacom/__init__.py
@@ -153,9 +153,18 @@ def tablet(ctx, device):
     """
     Show or change configuration for a tablet device.
 
-    DEVICE is a vendor/product ID tuple in the form 1234:abcd.
+    DEVICE is a vendor/product ID tuple in the form 1234:abcd or it may
+    be provided as the special devices "first" as the first device listed by
+    list-tablets. Using "first" requires the tablet to be plugged in.
     """
-    vid, pid = (int(x, 16) for x in device.split(":"))
+    if device == "first":
+        tablet = next(list_tablets(), None)
+        if tablet is None:
+            msg = "Unable to find any devices, cannot use 'first'"
+            raise click.UsageError(msg)
+        vid, pid = tablet.vid, tablet.pid
+    else:
+        vid, pid = (int(x, 16) for x in device.split(":"))
     path = f"/org/gnome/desktop/peripherals/tablets/{vid:04x}:{pid:04x}/"
     schema = "org.gnome.desktop.peripherals.tablet"
     ctx.obj = Settings(path, Gio.Settings.new_with_path(schema, path))


### PR DESCRIPTION
Wrote the code but when writing the commit message I thought better of it - yes it makes a few bits slightly simpler but it *will* be used in script and then not behave correctly if the tablet is missing.

So I'm filing this so it's backed up and closing it immediately.