### PR TITLE
If the tablet is not mapped to any monitor, print a comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ devices:
     keep-aspect: false
     left-handed: false
     mapping: 'absolute'
-    output: ['', '', '']
+    output: ['', '', '']  # not mapped to any monitor
 - name: "Wacom Intuos Pro M Pen"
   usbid: "056A:0357"
   settings:

--- a/src/gsetwacom/__init__.py
+++ b/src/gsetwacom/__init__.py
@@ -82,7 +82,11 @@ def print_tablet_settings(settings, indent=0):
     keys = ("area", "keep-aspect", "left-handed", "mapping", "output")
     click.echo(f"{indent}settings:")
     for key in filter(lambda k: settings.has_key(k), keys):
-        click.echo(f"{indent}  {key}: {settings.get_value(key)}")
+        value = settings.get_value(key)
+        comment = ""
+        if key == "output" and all(not v for v in value):
+            comment = "  # not mapped to any monitor"
+        click.echo(f"{indent}  {key}: {value}{comment}")
 
 
 def print_stylus_settings(settings, indent=0):


### PR DESCRIPTION
Makes the output easier to understand since empty strings look more like a bug than a "not mapped" setting. Output is now something like:

        settings:
          area: [0.0, 0.0, 0.0, 0.0]
          keep-aspect: true
          left-handed: false
          mapping: 'absolute'
          output: ['', '', '']  # not mapped to any monitor

cc @Deevad